### PR TITLE
Prevent backspace from returning to previous page.

### DIFF
--- a/src/components/textbox.ts
+++ b/src/components/textbox.ts
@@ -239,6 +239,7 @@ const handleKeyDown = async (e: KeyboardEvent) => {
 
   // backspace
   if (e.key === 'Backspace') {
+    e.preventDefault() // prevents backspace from returning to previous page
     if (currentWordLetter > 0) {
       ta[currentWord].letters[currentWordLetter].active = false
       currentLetter--


### PR DESCRIPTION
On some browsers (I tested on MS Edge) pressing the backspace key returns to previous page. Having that happen in a typing game where errors are plentiful is a game breaking glitch. `preventDefault()` on backspace key press fixes this.